### PR TITLE
Integrate dependencies into pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ These instructions will get you a copy of the project up and running on your loc
 
 #### Installation
 
-You need to have Python installed on your machine. The project also has some dependencies, which can be installed with pip:
+You need to have Python installed on your machine. The project uses `pyproject.toml` to manage dependencies. To install the dependencies, you can use a package manager like `pip`:
 
 ```
-pip install -r requirements.txt
+pip install .
 ```
 
 #### Running the Script

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,13 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+
+[project.dependencies]
+torch = "~2.1"
+numpy = "~1.24"
+transformers = "~4.36"
+datasets = "~2.14"
+fire = "~0.4"
+accelerate = "~0.25"
+transformers-stream-generator = "~0.0.4"
+torch_optimizer = "~0.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-torch~=2.1
-numpy~=1.24
-transformers~=4.36
-datasets~=2.14
-fire~=0.4
-accelerate~=0.25
-transformers-stream-generator~=0.0.4
-torch_optimizer~=0.3


### PR DESCRIPTION
This PR moves the dependency management from using a `requirements.tx`t file to specifying dependencies directly in `pyproject.toml`. This change aligns with [PEP 621](https://peps.python.org/pep-0621/#dependencies-optional-dependencies), which recommends declaring project metadata in pyproject.toml. It simplifies dependency management and ensures consistency with modern Python packaging standards.

The README.md has also been updated to reflect the new installation instructions.

Specifying dependencies in the pyproject.toml also makes it easier to add optional dependencies in the future.