### PR TITLE
Dependencies import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,14 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-
-[project.dependencies]
-torch = "~2.1"
-numpy = "~1.24"
-transformers = "~4.36"
-datasets = "~2.14"
-fire = "~0.4"
-accelerate = "~0.25"
-transformers-stream-generator = "~0.0.4"
-torch_optimizer = "~0.3"
+dependencies=[
+  "torch ~= 2.1"
+  "numpy ~= 1.24"
+  "transformers ~= 4.36"
+  "datasets ~= 2.14"
+  "fire ~= 0.4"
+  "accelerate ~= 0.25"
+  "transformers-stream-generator ~= 0.0.4"
+  "torch_optimizer ~= 0.3",
+  "wandb ~= 0.16.1"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies=[
-  "torch ~= 2.1"
-  "numpy ~= 1.24"
-  "transformers ~= 4.36"
-  "datasets ~= 2.14"
-  "fire ~= 0.4"
-  "accelerate ~= 0.25"
-  "transformers-stream-generator ~= 0.0.4"
+  "torch ~= 2.1",
+  "numpy ~= 1.24",
+  "transformers ~= 4.36",
+  "datasets ~= 2.14",
+  "fire ~= 0.4",
+  "accelerate ~= 0.25",
+  "transformers-stream-generator ~= 0.0.4",
   "torch_optimizer ~= 0.3",
   "wandb ~= 0.16.1"
 ]


### PR DESCRIPTION
TypeError: Field `project.dependencies` must be an array.
This error is thrown when trying to run pip install . 
Thus I created an array and stored versions within.
running pip install . works directly
Added wandb version(optional) since it is required when you run the train_weak_to _strong.py file
