### PR TITLE
pyproject.toml minor fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dump
 *.pyc
 *.swp
 *.swo
+venv/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,15 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-[project.dependencies]
-torch = "~2.1"
-numpy = "~1.24"
-transformers = "~4.36"
-datasets = "~2.14"
-fire = "~0.4"
-accelerate = "~0.25"
-transformers-stream-generator = "~0.0.4"
-torch_optimizer = "~0.3"
+dependencies = [
+    "torch~=2.1",
+    "numpy~=1.24",
+    "transformers~=4.36",
+    "datasets~=2.14",
+    "fire~=0.4",
+    "accelerate~=0.25",
+    "transformers-stream-generator~=0.0.4",
+    "torch_optimizer~=0.3"
+]
+
+


### PR DESCRIPTION
Dependencies inside pyprojcet.toml should be an array in order for pip install . to work. Fixed it.