### PR TITLE
fix mini_batch_size being referenced before assignment (openai#25)

### DIFF
--- a/weak_to_strong/train.py
+++ b/weak_to_strong/train.py
@@ -231,9 +231,11 @@ def train_and_save_model(
         ).to("cuda")
         already_trained = maybe_load_model(model)
         # data parallel:  currently not supported with model parallel
+
+        minibatch_size = min(minibatch_size_per_device * torch.cuda.device_count(), batch_size)
+
         if torch.cuda.device_count() > 1:
             model = torch.nn.DataParallel(model, output_device=0)
-            minibatch_size = min(minibatch_size_per_device * torch.cuda.device_count(), batch_size)
             print(
                 "Using",
                 torch.cuda.device_count(),


### PR DESCRIPTION
Quick fix for #25

[Working Colab notebook](https://colab.research.google.com/drive/1tWYoKqeHFyz9nNwbcfjjwZQ_BCxbkCTD?usp=sharing)

Note: This notebook successfully trains the weak model, but encounters a separate error when training the strong one.